### PR TITLE
Set FEN position in Stockfish after validating FEN

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ class ChessEngine:
         self.stockfish = self._initialize_stockfish(stockfish_path)
         if self.is_fen_valid(board_fen):
             self.board = chess.Board(board_fen)
+            self.stockfish.set_fen_position(self.board.fen())
         else:
             print('Invalid FEN')
             self.board = None


### PR DESCRIPTION
Added a line of code to main.py to ensure that the FEN position is set directly in Stockfish after verification. This is necessary to align the Stockfish engine's position with the initially validated and set board state.